### PR TITLE
core/vm,params: remove Rules type and uses

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -101,7 +101,7 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	// The legacy gas metering only takes into consideration the current state
 	// Legacy rules should be applied if we are in Petersburg (removal of EIP-1283)
 	// OR Constantinople is not active
-	if evm.chainRules.IsPetersburg || !evm.chainRules.IsConstantinople {
+	if evm.chainConfig.IsPetersburg(evm.BlockNumber) || !evm.chainConfig.IsConstantinople(evm.BlockNumber) {
 		// This checks for 3 scenario's and calculates gas accordingly:
 		//
 		// 1. From a zero-value address to a non-zero value         (NEW VALUE)
@@ -331,7 +331,7 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		transfersValue = stack.Back(2).Sign() != 0
 		address        = common.BigToAddress(stack.Back(1))
 	)
-	if evm.chainRules.IsEIP158 {
+	if evm.chainConfig.IsEIP158(evm.BlockNumber) {
 		if transfersValue && evm.StateDB.Empty(address) {
 			gas += params.CallNewAccountGas
 		}
@@ -350,7 +350,7 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		return 0, errGasUintOverflow
 	}
 
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	evm.callGasTemp, err = callGas(evm.chainConfig.IsEIP150(evm.BlockNumber), contract.Gas, gas, stack.Back(0))
 	if err != nil {
 		return 0, err
 	}
@@ -375,7 +375,7 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if gas, overflow = math.SafeAdd(gas, memoryGas); overflow {
 		return 0, errGasUintOverflow
 	}
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	evm.callGasTemp, err = callGas(evm.chainConfig.IsEIP150(evm.BlockNumber), contract.Gas, gas, stack.Back(0))
 	if err != nil {
 		return 0, err
 	}
@@ -390,7 +390,7 @@ func gasDelegateCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	if err != nil {
 		return 0, err
 	}
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	evm.callGasTemp, err = callGas(evm.chainConfig.IsEIP150(evm.BlockNumber), contract.Gas, gas, stack.Back(0))
 	if err != nil {
 		return 0, err
 	}
@@ -406,7 +406,7 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	if err != nil {
 		return 0, err
 	}
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	evm.callGasTemp, err = callGas(evm.chainConfig.IsEIP150(evm.BlockNumber), contract.Gas, gas, stack.Back(0))
 	if err != nil {
 		return 0, err
 	}
@@ -420,11 +420,11 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var gas uint64
 	// EIP150 homestead gas reprice fork:
-	if evm.chainRules.IsEIP150 {
+	if evm.chainConfig.IsEIP150(evm.BlockNumber) {
 		gas = params.SelfdestructGasEIP150
 		var address = common.BigToAddress(stack.Back(0))
 
-		if evm.chainRules.IsEIP158 {
+		if evm.chainConfig.IsEIP158(evm.BlockNumber) {
 			// if empty and transfers value
 			if evm.StateDB.Empty(address) && evm.StateDB.GetBalance(contract.Address()).Sign() != 0 {
 				gas += params.CreateBySelfdestructGas

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -692,7 +692,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memor
 		input        = memory.GetCopy(offset.Int64(), size.Int64())
 		gas          = contract.Gas
 	)
-	if interpreter.evm.chainRules.IsEIP150 {
+	if interpreter.evm.chainConfig.IsEIP150(interpreter.evm.BlockNumber) {
 		gas -= gas / 64
 	}
 
@@ -702,7 +702,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memor
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
 	// rule) and treat as an error, if the ruleset is frontier we must
 	// ignore this error and pretend the operation was successful.
-	if interpreter.evm.chainRules.IsHomestead && suberr == ErrCodeStoreOutOfGas {
+	if interpreter.evm.chainConfig.IsHomestead(interpreter.evm.BlockNumber) && suberr == ErrCodeStoreOutOfGas {
 		stack.push(interpreter.intPool.getZero())
 	} else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
 		stack.push(interpreter.intPool.getZero())

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -93,17 +93,17 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	if !cfg.JumpTable[STOP].valid {
 		var jt JumpTable
 		switch {
-		case evm.chainRules.IsIstanbul:
+		case evm.chainConfig.IsIstanbul(evm.BlockNumber):
 			jt = istanbulInstructionSet
-		case evm.chainRules.IsConstantinople:
+		case evm.chainConfig.IsConstantinople(evm.BlockNumber):
 			jt = constantinopleInstructionSet
-		case evm.chainRules.IsByzantium:
+		case evm.chainConfig.IsByzantium(evm.BlockNumber):
 			jt = byzantiumInstructionSet
-		case evm.chainRules.IsEIP158:
+		case evm.chainConfig.IsEIP158(evm.BlockNumber):
 			jt = spuriousDragonInstructionSet
-		case evm.chainRules.IsEIP150:
+		case evm.chainConfig.IsEIP150(evm.BlockNumber):
 			jt = tangerineWhistleInstructionSet
-		case evm.chainRules.IsHomestead:
+		case evm.chainConfig.IsHomestead(evm.BlockNumber):
 			jt = homesteadInstructionSet
 		default:
 			jt = frontierInstructionSet
@@ -214,7 +214,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			return nil, fmt.Errorf("stack limit reached %d (%d)", sLen, operation.maxStack)
 		}
 		// If the operation is valid, enforce and write restrictions
-		if in.readOnly && in.evm.chainRules.IsByzantium {
+		if in.readOnly && in.evm.chainConfig.IsByzantium(in.evm.BlockNumber) {
 			// If the interpreter is operating in readonly mode, make sure no
 			// state-modifying operation is performed. The 3rd stack item
 			// for a call operation is the value. Transferring value from one

--- a/core/vm/interpreter_rules_test.go
+++ b/core/vm/interpreter_rules_test.go
@@ -1,0 +1,56 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+)
+
+type InterpretBotRules struct {
+	IsEnabled bool
+}
+
+type InterpretbotConfig struct {
+	EnabledAt *big.Int
+}
+
+func (i *InterpretbotConfig) IsEnabled(n *big.Int) bool {
+	if i.EnabledAt == nil || n == nil {
+		return false
+	}
+	return n.Cmp(i.EnabledAt) >= 0
+}
+
+func (i *InterpretbotConfig) Rules(n *big.Int) InterpretBotRules {
+	return InterpretBotRules{
+		IsEnabled: i.IsEnabled(n),
+	}
+}
+
+type Interpretbot struct {
+	Rules InterpretBotRules
+	Config *InterpretbotConfig
+}
+
+func setupInterpretBot() *Interpretbot {
+	conf := &InterpretbotConfig{EnabledAt:big.NewInt(42)}
+	return &Interpretbot{
+		Config: conf,
+	}
+}
+
+func BenchmarkPatternRules(b *testing.B) {
+	ib := setupInterpretBot()
+	n := big.NewInt(43)
+	ib.Rules = ib.Config.Rules(n)
+	for i := 0; i < b.N; i++ {
+		if ib.Rules.IsEnabled {}
+	}
+}
+
+func BenchmarkPatternConfig(b *testing.B) {
+	ib := setupInterpretBot()
+	n := big.NewInt(43)
+	for i := 0; i < b.N; i++ {
+		if ib.Config.IsEnabled(n) {}
+	}
+}

--- a/params/config.go
+++ b/params/config.go
@@ -225,7 +225,6 @@ var (
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}}
 
 	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil}
-	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -559,32 +558,3 @@ func (err *ConfigCompatError) Error() string {
 	return fmt.Sprintf("mismatching %s in database (have %d, want %d, rewindto %d)", err.What, err.StoredConfig, err.NewConfig, err.RewindTo)
 }
 
-// Rules wraps ChainConfig and is merely syntactic sugar or can be used for functions
-// that do not have or require information about the block.
-//
-// Rules is a one time interface meaning that it shouldn't be used in between transition
-// phases.
-type Rules struct {
-	ChainID                                                 *big.Int
-	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
-	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-}
-
-// Rules ensures c's ChainID is not nil.
-func (c *ChainConfig) Rules(num *big.Int) Rules {
-	chainID := c.ChainID
-	if chainID == nil {
-		chainID = new(big.Int)
-	}
-	return Rules{
-		ChainID:          new(big.Int).Set(chainID),
-		IsHomestead:      c.IsHomestead(num),
-		IsEIP150:         c.IsEIP150(num),
-		IsEIP155:         c.IsEIP155(num),
-		IsEIP158:         c.IsEIP158(num),
-		IsByzantium:      c.IsByzantium(num),
-		IsConstantinople: c.IsConstantinople(num),
-		IsPetersburg:     c.IsPetersburg(num),
-		IsIstanbul:       c.IsIstanbul(num),
-	}
-}


### PR DESCRIPTION
This type was a vestige of a time gone by, used mostly
in tests. It's current uses are duplicated by existing
methods in ChainConfig.